### PR TITLE
feat: use hono client for frontend api

### DIFF
--- a/src/worker-env.d.ts
+++ b/src/worker-env.d.ts
@@ -1,0 +1,2 @@
+// Minimal global definition to satisfy frontend type checking for Cloudflare's D1Database.
+type D1Database = unknown;

--- a/worker/api/index.ts
+++ b/worker/api/index.ts
@@ -458,4 +458,6 @@ app.use(
   })
 );
 
+export type AppType = typeof app;
+
 export default app;


### PR DESCRIPTION
## Summary
- expose `AppType` from worker API for client consumption
- replace custom fetch wrapper with typed `hono/client` usage
- stub Cloudflare `D1Database` type for frontend type checking

## Testing
- `pnpm format`
- `pnpm lint` (warnings: console usage and any type)
- `pnpm typecheck`
- `pnpm worker:test run` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68b42640b4608329b824b2e61fe057ac